### PR TITLE
Disable block delimiters rule for specs

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -129,3 +129,7 @@ RSpec/NotToNot:
 
 RSpec/VerifiedDoubles:
   Enabled: false
+
+Style/BlockDelimiters:
+  Exclude:
+    ['spec/**/*_spec.rb']


### PR DESCRIPTION
For RSpec blocks, I will often write something like the following:

```ruby
  expect {
    human.feed(marshmallows: true)
  }.to change(life, :meaning).from(0).to(42)
```

This change makes the above possible without offending Ruby's honor.