### PR TITLE
Update rubocop, rubocop-rspec, default configuration

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -75,7 +75,7 @@ Naming/UncommunicativeMethodParamName:
   Enabled: false
 
 Style/AccessModifierDeclarations:
-  Enabled: false
+  EnforcedStyle: inline
 
 Style/BlockDelimiters:
   Exclude:
@@ -133,15 +133,6 @@ RSpec/Be:
 
 RSpec/DescribedClass:
   EnforcedStyle: explicit
-
-RSpec/EmptyLineAfterExampleGroup:
-  Enabled: false
-
-RSpec/EmptyLineAfterHook:
-  Enabled: false
-
-RSpec/EmptyLineAfterSubject:
-  Enabled: false
 
 RSpec/ExampleLength:
   Enabled: false

--- a/default.yml
+++ b/default.yml
@@ -44,16 +44,6 @@ Lint/RescueException:
 Metrics/LineLength:
   Max: 100
 
-Style/Documentation:
-  Enabled: false
-
-# Enable this to ease the transition to Ruby 3.0 where string literals will be frozen by default.
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/IfUnlessModifier:
-  Enabled: false
-
 Metrics/AbcSize:
   Enabled: false
 
@@ -78,13 +68,30 @@ Metrics/ParameterLists:
 Metrics/BlockLength:
   Enabled: false
 
-Style/DoubleNegation:
-  Enabled: false
-
 Naming/FileName:
   Exclude: ['Gemfile', 'Guardfile']
 
 Naming/UncommunicativeMethodParamName:
+  Enabled: false
+
+Style/AccessModifierDeclarations:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
+Style/Documentation:
+  Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false
+
+# Enable this to ease the transition to Ruby 3.0 where string literals will be frozen by default.
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/IfUnlessModifier:
   Enabled: false
 
 Style/FormatStringToken:
@@ -127,6 +134,15 @@ RSpec/Be:
 RSpec/DescribedClass:
   EnforcedStyle: explicit
 
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: false
+
+RSpec/EmptyLineAfterHook:
+  Enabled: false
+
+RSpec/EmptyLineAfterSubject:
+  Enabled: false
+
 RSpec/ExampleLength:
   Enabled: false
 
@@ -139,6 +155,9 @@ RSpec/MultipleExpectations:
 RSpec/ImplicitExpect:
   EnforcedStyle: should
 
+RSpec/ImplicitSubject:
+  Enabled: false
+
 RSpec/MessageSpies:
   EnforcedStyle: receive
 
@@ -150,7 +169,3 @@ RSpec/NotToNot:
 
 RSpec/VerifiedDoubles:
   Enabled: false
-
-Style/BlockDelimiters:
-  Exclude:
-    ['spec/**/*_spec.rb']

--- a/percy-style.gemspec
+++ b/percy-style.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.53"
-  spec.add_dependency "rubocop-rspec", "~> 1.24"
+  spec.add_dependency "rubocop-rspec", "~> 1.29"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/percy-style.gemspec
+++ b/percy-style.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.53"
-  spec.add_dependency "rubocop-rspec", "~> 1.29"
+  spec.add_dependency "rubocop", "~> 0.58.2"
+  spec.add_dependency "rubocop-rspec", "~> 1.29.1"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
A couple things going on in here:

1. Updated the `rubocop` and `rubocop-rspec` dependencies to the latest version.

2. Updated the gemspec to target more specific versions of `rubocop` and `rubocop-rspec` (i.e., allowing only patch-level variance in the dependency specification).

Since minor version bumps of the two almost always introduce new rules that make the existing code no longer pass CI, `percy-style` should really be more strict about what versions of the library it's targeting, and applications should be more strict about what version of `percy-style` they target. This recognizes that the style guide (and underlying libraries) evolve over time, and take maintenance work to update. 

3. Disabled some new rules with a huge number of violations in the API project. Will discuss these inline below.

4. Alphabetized some stray entries in `default.yml`.