### PR TITLE
Remove TargetRubyVersion; let it be handled by .ruby-version file

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,7 +1,6 @@
 require: rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.4
   Include:
     - Rakefile
     - lib/**/*.rake


### PR DESCRIPTION
Just one less thing to have to remember to update when you upgrade Ruby

rubocop-hq/rubocop#3228