### PR TITLE
Update to rubocop 0.65 and rubocop-rspec 1.32

### DIFF
--- a/percy-style.gemspec
+++ b/percy-style.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.58.2"
-  spec.add_dependency "rubocop-rspec", "~> 1.29.1"
+  spec.add_dependency "rubocop", "~> 0.65.0"
+  spec.add_dependency "rubocop-rspec", "~> 1.32.0"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
https://github.com/rubocop-hq/rubocop/blob/v0.65.0/CHANGELOG.md
https://github.com/rubocop-hq/rubocop-rspec/blob/v1.32.0/CHANGELOG.md