### PR TITLE
Update rubocop and rubocop-rspec

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -44,7 +44,7 @@ Lint/RescueException:
   Exclude:
     - 'lib/tasks/*.rake'
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
 
 Metrics/AbcSize:

--- a/default.yml
+++ b/default.yml
@@ -1,6 +1,7 @@
 require: rubocop-rspec
 
 AllCops:
+  NewCops: enable
   TargetRubyVersion: 2.4
   Include:
     - Rakefile

--- a/default.yml
+++ b/default.yml
@@ -164,3 +164,6 @@ RSpec/NotToNot:
 
 RSpec/VerifiedDoubles:
   Enabled: false
+
+Style/SingleArgumentDig:
+  Enabled: false

--- a/default.yml
+++ b/default.yml
@@ -167,3 +167,6 @@ RSpec/VerifiedDoubles:
 
 Style/SingleArgumentDig:
   Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/lib/percy/style/version.rb
+++ b/lib/percy/style/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Style
-    VERSION = '0.7.0'.freeze
+    VERSION = '0.8.0'.freeze
   end
 end

--- a/percy-style.gemspec
+++ b/percy-style.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.77.0"
-  spec.add_dependency "rubocop-rspec", "~> 1.37.0"
+  spec.add_dependency "rubocop", "~> 1.12.1"
+  spec.add_dependency "rubocop-rspec", "~> 2.2.0"
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
Upgrade rubocop: `0.77.0` => `1.21.1` [Changelog](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#0770-2019-11-27)
Upgrade rubocop-rspec: `1.37.0` => `2.2.0` [Changelog](https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#1370-2019-11-25)