### PR TITLE
Minor rubocop upgrade

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,7 +1,8 @@
 require: rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.4
+  NewCops: enable
+  TargetRubyVersion: 2.7
   Include:
     - Rakefile
     - lib/**/*.rake
@@ -36,6 +37,9 @@ Layout/MultilineOperationIndentation:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
+Layout/LineLength:
+  Max: 100
+
 # This seems to break some require lines somehow:
 Layout/EmptyLinesAroundArguments:
   Enabled: false
@@ -43,9 +47,6 @@ Layout/EmptyLinesAroundArguments:
 Lint/RescueException:
   Exclude:
     - 'lib/tasks/*.rake'
-
-Metrics/LineLength:
-  Max: 100
 
 Metrics/AbcSize:
   Enabled: false

--- a/default.yml
+++ b/default.yml
@@ -1,8 +1,6 @@
 require: rubocop-rspec
 
 AllCops:
-  NewCops: enable
-  TargetRubyVersion: 2.7
   Include:
     - Rakefile
     - lib/**/*.rake

--- a/default.yml
+++ b/default.yml
@@ -1,6 +1,7 @@
 require: rubocop-rspec
 
 AllCops:
+  TargetRubyVersion: 2.7
   Include:
     - Rakefile
     - lib/**/*.rake

--- a/lib/percy/style/version.rb
+++ b/lib/percy/style/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Style
-    VERSION = '0.8.0'.freeze
+    VERSION = '0.7.1'.freeze
   end
 end

--- a/lib/percy/style/version.rb
+++ b/lib/percy/style/version.rb
@@ -1,5 +1,5 @@
 module Percy
   module Style
-    VERSION = '0.7.0'.freeze
+    VERSION = '0.8.0'.freeze
   end
 end

--- a/percy-style.gemspec
+++ b/percy-style.gemspec
@@ -28,8 +28,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 1.36"
-  spec.add_dependency "rubocop-rspec", "~> 2.12"
+  # Handle Ruby 2.7 forward arguments properly in rubocop v0.79.0
+  # https://github.com/rubocop/rubocop/pull/7605
+  spec.add_dependency "rubocop", "~> 0.80"
+  spec.add_dependency "rubocop-rspec", "~> 1.37.0"
   spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "rake", "~> 13.0"
 end

--- a/percy-style.gemspec
+++ b/percy-style.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.77.0"
-  spec.add_dependency "rubocop-rspec", "~> 1.37.0"
-  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_dependency "rubocop", "~> 1.36"
+  spec.add_dependency "rubocop-rspec", "~> 2.12"
+  spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
The current version of rubocop cannot handle the following code:
```ruby
def foo(...)
  bar(...)
end
```

```ruby
undefined method `on_forwarded_args' for #<RuboCop::Cop::Commissioner:0x0000556ebdded560>
  | /app/.bundle/ruby/2.7.0/gems/rubocop-0.77.0/lib/rubocop/ast/traversal.rb:107:in `block in on_send'
  | /app/.bundle/ruby/2.7.0/gems/rubocop-0.77.0/lib/rubocop/ast/traversal.rb:104:in `each'
  | /app/.bundle/ruby/2.7.0/gems/rubocop-0.77.0/lib/rubocop/ast/traversal.rb:104:in `each_with_index'
  | /app/.bundle/ruby/2.7.0/gems/rubocop-0.77.0/lib/rubocop/ast/traversal.rb:104:in `on_send'
```
